### PR TITLE
Flag switch "-kasm-range" --> "-n"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+kasm-stress-test*

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ This tool is designed to stress test Kasm Workspaces by creating multiple Kasm i
 3. Build the project:
    ```
    # Linux
-   go build -o kasm-stress-test cmd/kasm-stress-test/main.go
+   $env:GOOS="linux"; $env:GOARCH="amd64"; go build -o kasm-stress-test cmd/kasm-stress-test/main.go
 
    # Windows
-   go build -o kasm-stress-test.exe cmd/kasm-stress-test/main.go
+   $env:GOOS="windows"; $env:GOARCH="amd64"; go build -o kasm-stress-test.exe cmd/kasm-stress-test/main.go
    ```
 
 ## Configuration
@@ -60,7 +60,7 @@ Run the stress test with the following command:
 ./kasm-stress-test -u username@example.com -kasm-range 1-5
 
 # Windows
-.\kasm-stress-test -u username@example.com -kasm-range 1-5
+.\kasm-stress-test.exe -u username@example.com -kasm-range 1-5
 ```
 
 Command-line flags:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This tool is designed to stress test Kasm Workspaces by creating multiple Kasm i
 
 ## Features
 
-- Create multiple Kasm instances for a specified user
+- Create multiple Kasm instances for each specified user
 - Execute commands on each Kasm instance
 - Test Kasm's autoscaling capabilities
 - Detailed logging and error reporting
@@ -40,7 +40,6 @@ This tool is designed to stress test Kasm Workspaces by creating multiple Kasm i
 Create a `.kasm-stress-test.json` file in your home directory with the following structure:
 
 ```
-json
 {
 "api_key": "your-api-key",
 "api_secret": "your-api-secret",

--- a/README.md
+++ b/README.md
@@ -57,15 +57,15 @@ Run the stress test with the following command:
 
 ```
 # Linux
-./kasm-stress-test -u username@example.com -kasm-range 1-5
+./kasm-stress-test -u username@example.com -n 5
 
 # Windows
-.\kasm-stress-test.exe -u username@example.com -kasm-range 1-5
+.\kasm-stress-test.exe -u username@example.com -n 5
 ```
 
 Command-line flags:
 - `-u`: Username to use for the test (can be specified multiple times for multiple users)
-- `-kasm-range`: Range of Kasm instances to create (e.g., 1-5 will create 5 instances)
+- `-n`: Number of Kasm instances to create
 
 ## Output
 

--- a/cmd/kasm-stress-test/main.go
+++ b/cmd/kasm-stress-test/main.go
@@ -14,10 +14,10 @@ import (
 func main() {
 	utils.InitLoggers()
 	var usernames utils.StringSliceFlag
-	flag.Var(&usernames, "u", "Usernames to use (can be specified multiple times)")
+	flag.Var(&usernames, "u", "Username to use (can be specified multiple times)")
 
-	var kasmRange utils.IntRangeFlag
-	flag.Var(&kasmRange, "kasm-range", "Range of Kasm instances to create (e.g., 5-10)")
+	var sessionNum utils.IntFlag
+	flag.Var(&sessionNum, "n", "Number of Kasm Sessions to start for each username specified")
 
 	flag.Parse()
 
@@ -25,8 +25,8 @@ func main() {
 		log.Fatal("At least one username is required")
 	}
 
-	if kasmRange.Min == 0 || kasmRange.Max == 0 {
-		log.Fatal("Invalid Kasm range")
+	if len(sessionNum.String()) == 0 {
+		log.Fatal("Please provide the number of sessions to start")
 	}
 
 	cfg, err := config.Load()
@@ -39,7 +39,7 @@ func main() {
 	var allResults []*models.StressTestResult
 
 	for _, username := range usernames {
-		runner := stress.NewRunner(cfg, username, kasmRange)
+		runner := stress.NewRunner(cfg, username, sessionNum)
 		results := runner.Run()
 		allResults = append(allResults, results)
 	}

--- a/internal/stress/runner.go
+++ b/internal/stress/runner.go
@@ -11,18 +11,18 @@ import (
 )
 
 type Runner struct {
-	client    *api.Client
-	config    *config.Config
-	username  string
-	kasmRange utils.IntRangeFlag
+	client     *api.Client
+	config     *config.Config
+	username   string
+	sessionNum utils.IntFlag
 }
 
-func NewRunner(cfg *config.Config, username string, kasmRange utils.IntRangeFlag) *Runner {
+func NewRunner(cfg *config.Config, username string, sessionNum utils.IntFlag) *Runner {
 	return &Runner{
-		client:    api.NewClient(cfg),
-		config:    cfg,
-		username:  username,
-		kasmRange: kasmRange,
+		client:     api.NewClient(cfg),
+		config:     cfg,
+		username:   username,
+		sessionNum: sessionNum,
 	}
 }
 
@@ -30,7 +30,7 @@ func (r *Runner) Run() *models.StressTestResult {
 	startTime := time.Now()
 	result := &models.StressTestResult{
 		Username:   r.username,
-		TotalKasms: r.kasmRange.Max - r.kasmRange.Min + 1,
+		TotalKasms: r.sessionNum.Value,
 	}
 
 	user, err := r.client.GetUserInfo(r.username)
@@ -41,8 +41,8 @@ func (r *Runner) Run() *models.StressTestResult {
 
 	var kasmsToDestroy []string
 
-	for numKasms := r.kasmRange.Min; numKasms <= r.kasmRange.Max; numKasms++ {
-		kasmResult := r.createAndTestKasm(numKasms, user.UserID)
+	for i := 0; i <= r.sessionNum.Value; i++ {
+		kasmResult := r.createAndTestKasm(i, user.UserID)
 		result.KasmResults = append(result.KasmResults, kasmResult)
 
 		if kasmResult.ExecutionError == "" {
@@ -50,7 +50,7 @@ func (r *Runner) Run() *models.StressTestResult {
 			kasmsToDestroy = append(kasmsToDestroy, kasmResult.KasmID)
 		} else {
 			result.FailedKasms++
-			result.Errors = append(result.Errors, fmt.Sprintf("Kasm %d: %s", numKasms, kasmResult.ExecutionError))
+			result.Errors = append(result.Errors, fmt.Sprintf("Kasm %d: %s", i, kasmResult.ExecutionError))
 		}
 		result.AverageStartTime += kasmResult.StartTime
 	}

--- a/internal/stress/runner.go
+++ b/internal/stress/runner.go
@@ -41,7 +41,7 @@ func (r *Runner) Run() *models.StressTestResult {
 
 	var kasmsToDestroy []string
 
-	for i := 0; i <= r.sessionNum.Value; i++ {
+	for i := 0; i < r.sessionNum.Value; i++ {
 		kasmResult := r.createAndTestKasm(i, user.UserID)
 		result.KasmResults = append(result.KasmResults, kasmResult)
 

--- a/internal/utils/flags.go
+++ b/internal/utils/flags.go
@@ -25,42 +25,30 @@ func (s *StringSliceFlag) Type() string {
 }
 
 // IntRangeFlag is a custom flag type for specifying a range of integers
-type IntRangeFlag struct {
-	Min, Max int
+type IntFlag struct {
+	Value int
 }
 
-// String returns a string representation of the IntRangeFlag
-func (i *IntRangeFlag) String() string {
-	return fmt.Sprintf("%d-%d", i.Min, i.Max)
+// String returns a string representation of the IntFlag
+func (i *IntFlag) String() string {
+	return fmt.Sprintf("%d", i.Value)
 }
 
 // Set parses a string in the format "min-max" and sets the Min and Max values
-func (i *IntRangeFlag) Set(value string) error {
-	parts := strings.Split(value, "-")
-	if len(parts) != 2 {
-		return fmt.Errorf("invalid range format, expected min-max")
-	}
-
-	_, err := fmt.Sscanf(value, "%d-%d", &i.Min, &i.Max)
+func (i *IntFlag) Set(value string) error {
+	_, err := fmt.Sscanf(value, "%d", &i.Value)
 	if err != nil {
-		return fmt.Errorf("invalid range format: %w", err)
+		return fmt.Errorf("invalid integer format: %w", err)
 	}
-
-	if i.Min > i.Max {
-		return fmt.Errorf("min value cannot be greater than max value")
-	}
-
 	return nil
 }
 
 // Type returns the type of the flag as a string
-func (i *IntRangeFlag) Type() string {
-	return "intRange"
+func (i *IntFlag) Type() string {
+	return "int"
 }
 
 // ParseFlags is a utility function to parse command-line flags
 func ParseFlags() error {
-	// This function can be implemented if you need custom flag parsing logic
-	// For now, we'll leave it as a placeholder
 	return nil
 }


### PR DESCRIPTION
- Changing the "-kasm-range" command line flag to "-n"
- Updates the flag to accept a single integer instead of a range now
- Updates README.md to reflect new CLI usage