### PR TITLE
Adding command choice as a flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ This tool is designed to stress test Kasm Workspaces by creating multiple Kasm i
 - Go 1.16 or higher
 - Access to a Kasm Workspaces deployment
 - API key and secret for the Kasm API
+- Your API key must be granted the following permissions in order for the tool to function:
+   - Users Auth Session
+   - User
+   - Sessions View
+   - Sessions Modify
+   - Images View
 
 ## Installation
 
@@ -56,15 +62,16 @@ Run the stress test with the following command:
 
 ```
 # Linux
-./kasm-stress-test -u username@example.com -n 5
+./kasm-stress-test -u username@example.com -n 5 -c all
 
 # Windows
-.\kasm-stress-test.exe -u username@example.com -n 5
+.\kasm-stress-test.exe -u username@example.com -n 5 -c all
 ```
 
 Command-line flags:
-- `-u`: Username to use for the test (can be specified multiple times for multiple users)
-- `-n`: Number of Kasm instances to create
+- `-u`, `--username`: Username to use for the test (can be specified multiple times for multiple users)
+- `-n`, `--number`: Number of Kasm instances to create
+- `-c`, `--command`: Command to run: 'cpu', 'network', or 'all' (default)
 
 ## Output
 

--- a/cmd/kasm-stress-test/main.go
+++ b/cmd/kasm-stress-test/main.go
@@ -15,9 +15,15 @@ func main() {
 	utils.InitLoggers()
 	var usernames utils.StringSliceFlag
 	flag.Var(&usernames, "u", "Username to use (can be specified multiple times)")
+	flag.Var(&usernames, "username", "Username to use (can be specified multiple times)")
 
 	var sessionNum utils.IntFlag
 	flag.Var(&sessionNum, "n", "Number of Kasm Sessions to start for each username specified")
+	flag.Var(&sessionNum, "number", "Number of Kasm Sessions to start for each username specified")
+
+	var command string
+	flag.StringVar(&command, "c", "all", "Command to run: 'cpu', 'network', or 'all' (default)")
+	flag.StringVar(&command, "command", "all", "Command to run: 'cpu', 'network', or 'all' (default)")
 
 	flag.Parse()
 
@@ -39,7 +45,7 @@ func main() {
 	var allResults []*models.StressTestResult
 
 	for _, username := range usernames {
-		runner := stress.NewRunner(cfg, username, sessionNum)
+		runner := stress.NewRunner(cfg, username, sessionNum, command)
 		results := runner.Run()
 		allResults = append(allResults, results)
 	}
@@ -52,6 +58,7 @@ func main() {
 		fmt.Printf("Successful Kasms: %d\n", result.SuccessfulKasms)
 		fmt.Printf("Failed Kasms: %d\n", result.FailedKasms)
 		fmt.Printf("Average start time: %.2f seconds\n", result.AverageStartTime.Seconds())
+		fmt.Printf("Total duration: %.2f seconds\n", result.TotalDuration.Seconds())
 
 		if len(result.Errors) > 0 {
 			fmt.Println("Errors encountered:")

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -81,24 +81,3 @@ func (c *Client) apiRequest(endpoint string, additionalData map[string]interface
 
 	return c.post(endpoint, requestBody)
 }
-
-// handleAPIResponse is a helper function to handle common API response structure
-func handleAPIResponse(respBody []byte, result interface{}) error {
-	// Try to unmarshal into a generic structure first
-	var genericResp map[string]interface{}
-	if err := json.Unmarshal(respBody, &genericResp); err != nil {
-		return fmt.Errorf("error unmarshaling API response: %w", err)
-	}
-
-	// Check for error messages
-	if errMsg, ok := genericResp["error_message"].(string); ok && errMsg != "" {
-		return fmt.Errorf("API request failed: %s", errMsg)
-	}
-
-	// If there's no error, try to unmarshal the entire response into the result
-	if err := json.Unmarshal(respBody, result); err != nil {
-		return fmt.Errorf("error unmarshaling API result: %w", err)
-	}
-
-	return nil
-}

--- a/internal/api/kasm.go
+++ b/internal/api/kasm.go
@@ -56,7 +56,7 @@ func (c *Client) GetKasmStatus(kasmID, user_id string) (*models.KasmStatus, erro
 }
 
 // ExecCommand executes a command in a Kasm session
-func (c *Client) ExecCommand(kasmID, userID, command string) (*models.CommandResult, error) {
+func (c *Client) ExecCommand(kasmID, userID, command string) error {
 	requestBody := map[string]interface{}{
 		"kasm_id": kasmID,
 		"user_id": userID,
@@ -65,17 +65,12 @@ func (c *Client) ExecCommand(kasmID, userID, command string) (*models.CommandRes
 		},
 	}
 
-	respBody, err := c.apiRequest("exec_command_kasm", requestBody)
+	_, err := c.apiRequest("exec_command_kasm", requestBody)
 	if err != nil {
-		return nil, fmt.Errorf("failed to execute command: %w", err)
+		return fmt.Errorf("failed to execute command: %w", err)
 	}
 
-	var result models.CommandResult
-	if err := json.Unmarshal(respBody, &result); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal command execution response: %w", err)
-	}
-
-	return &result, nil
+	return nil
 }
 
 // DestroyKasm destroys a Kasm session
@@ -130,15 +125,6 @@ func (c *Client) WaitForKasmReady(kasmID, image_id string, timeout time.Duration
 
 // GetAutoscalingStatus retrieves the current autoscaling status
 func (c *Client) GetAutoscalingStatus() (*models.AutoscalingStatus, error) {
-	respBody, err := c.apiRequest("get_autoscaling_status", nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get autoscaling status: %w", err)
-	}
-
-	var result models.AutoscalingStatus
-	if err := handleAPIResponse(respBody, &result); err != nil {
-		return nil, fmt.Errorf("failed to handle autoscaling status response: %w", err)
-	}
-
-	return &result, nil
+	// Placeholder for future implementation
+	return nil, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,6 @@ type Config struct {
 // Load reads the config file and environment variables to create a Config
 func Load() (*Config, error) {
 	config := &Config{
-		APIHost:  "https://beta.cmmc.space/api/public/",
 		LogLevel: "info",
 		Timeout:  30,
 	}


### PR DESCRIPTION
- Added CLI flag for `-c, --command`
	- Will run a different command or commands on each session dependent on flag input
- Added long form CLI flag usage
- Updated README to reflect new flags
- Removed default value for APIHost from config
- Removed function `handleAPIResponse()` from client.go as it was unused
- Updated command execution to change bases on input from `-c, --command`
- Removed references to command output as the Kasm API does not return this information