### PR TITLE
Flag switch

### DIFF
--- a/cmd/kasm-stress-test/main.go
+++ b/cmd/kasm-stress-test/main.go
@@ -14,6 +14,12 @@ import (
 )
 
 func main() {
+	err := utils.InitLoggers()
+	if err != nil {
+		log.Fatalf("Failed to initialize loggers: %v", err)
+	}
+	defer utils.CloseLogFile()
+
 	utils.InitLoggers()
 	var usernames utils.StringSliceFlag
 	flag.Var(&usernames, "u", "Username to use (can be specified multiple times)")
@@ -55,40 +61,40 @@ func main() {
 	}
 
 	// Process and print all results
-	fmt.Println("\n--- Stress Test Results ---")
+	utils.Console("\n--- Stress Test Results ---\n")
 	for _, result := range allResults {
-		fmt.Printf("\nResults for user: %s\n", result.Username)
-		fmt.Printf("Total Kasms created: %d\n", result.TotalKasms)
-		fmt.Printf("Successful Kasms: %d\n", result.SuccessfulKasms)
-		fmt.Printf("Failed Kasms: %d\n", result.FailedKasms)
-		fmt.Printf("Average start time: %.2f seconds\n", result.AverageStartTime.Seconds())
-		fmt.Printf("Total duration: %.2f seconds\n", result.TotalDuration.Seconds())
+		utils.Console("\nResults for user: %s\n", result.Username)
+		utils.Console("Total Kasms created: %d\n", result.TotalKasms)
+		utils.Console("Successful Kasms: %d\n", result.SuccessfulKasms)
+		utils.Console("Failed Kasms: %d\n", result.FailedKasms)
+		utils.Console("Average start time: %.2f seconds\n", result.AverageStartTime.Seconds())
+		utils.Console("Total duration: %.2f seconds\n", result.TotalDuration.Seconds())
 
 		if len(result.Errors) > 0 {
-			fmt.Println("Errors encountered:")
+			utils.Console("Errors encountered:\n")
 			for _, err := range result.Errors {
-				fmt.Printf("  - %s\n", err)
+				utils.Console("  - %s\n", err)
 			}
 		}
 
-		fmt.Println("\nDetailed Kasm Results:")
+		utils.Console("\nDetailed Kasm Results:\n")
 		for _, kasmResult := range result.KasmResults {
-			fmt.Printf("  Kasm #%d:\n", kasmResult.KasmNumber)
-			fmt.Printf("    Start time: %.2f seconds\n", kasmResult.StartTime.Seconds())
+			utils.Console("  Kasm #%d:\n", kasmResult.KasmNumber)
+			utils.Console("    Start time: %.2f seconds\n", kasmResult.StartTime.Seconds())
 			if kasmResult.ExecutionError != "" {
-				fmt.Printf("    Error: %s\n", kasmResult.ExecutionError)
+				utils.Console("    Error: %s\n", kasmResult.ExecutionError)
 			} else {
-				fmt.Println("    Status: Success")
+				utils.Console("    Status: Success\n")
 			}
 		}
-		fmt.Println(strings.Repeat("-", 30))
+		utils.Console("%s\n", strings.Repeat("-", 30))
 	}
 	utils.Info("Stress test completed")
 
 	// Prompt user to press Enter before destroying sessions
-	fmt.Println("\nPress Enter to destroy sessions and complete the test")
+	utils.Console("\nPress Enter to destroy sessions and complete the test\n")
 	bufio.NewReader(os.Stdin).ReadBytes('\n')
-	fmt.Println("Destroyig Sessions...")
+	utils.Console("Destroying Sessions...\n")
 
 	// Destroy all Sessions
 	var destroyErrors []error

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -36,7 +36,11 @@ type Kasm struct {
 
 // KasmStatus represents the status of a Kasm session
 type KasmStatus struct {
-	Kasm struct {
+	ErrorMessage        string `json:"error_message"`
+	OperationalMessage  string `json:"operational_message"`
+	OperationalProgress int    `json:"operational_progress"`
+	OperationalStatus   string `json:"operational_status"`
+	Kasm                struct {
 		KasmID            string `json:"kasm_id"`
 		OperationalStatus string `json:"operational_status"`
 		ContainerID       string `json:"container_id"`

--- a/internal/stress/runner.go
+++ b/internal/stress/runner.go
@@ -51,7 +51,9 @@ func (r *Runner) Run() *models.StressTestResult {
 
 		if kasmResult.ExecutionError == "" {
 			result.SuccessfulKasms++
-			r.kasmsToDestroy = append(r.kasmsToDestroy, kasmResult.KasmID)
+			if kasmResult.KasmID != "" {
+				r.kasmsToDestroy = append(r.kasmsToDestroy, kasmResult.KasmID)
+			}
 		} else {
 			result.FailedKasms++
 			result.Errors = append(result.Errors, fmt.Sprintf("Kasm %d: %s", i, kasmResult.ExecutionError))
@@ -69,10 +71,11 @@ func (r *Runner) Run() *models.StressTestResult {
 
 func (r *Runner) createAndTestKasm(numKasms int, userID string) models.KasmResult {
 	result := models.KasmResult{
-		KasmNumber: numKasms,
+		KasmNumber: numKasms + 1,
 	}
 
-	utils.Info("Starting test for Kasm %d", numKasms)
+	utils.Console("Starting session %d for user %s\n", numKasms+1, r.username)
+	utils.Info("Starting test for Kasm %d", numKasms+1)
 	startTime := time.Now()
 
 	// Step 1: Request Kasm
@@ -80,6 +83,12 @@ func (r *Runner) createAndTestKasm(numKasms int, userID string) models.KasmResul
 	kasm, err := r.client.RequestKasm(userID, r.config.DefaultImageID)
 	if err != nil {
 		utils.Error("Failed to request Kasm for user %s: %v", r.username, err)
+		result.ExecutionError = fmt.Sprintf("Failed to request Kasm: %v", err)
+		return result
+	}
+
+	if kasm == nil || kasm.KasmID == "" {
+		result.ExecutionError = "Received empty Kasm ID from API"
 		return result
 	}
 
@@ -89,7 +98,15 @@ func (r *Runner) createAndTestKasm(numKasms int, userID string) models.KasmResul
 	utils.Info("Step 2: Waiting for Kasm %s to be ready", kasm.KasmID)
 	err = r.client.WaitForKasmReady(kasm.KasmID, userID, 5*time.Minute)
 	if err != nil {
+		if strings.Contains(err.Error(), "stuck in 'requested' state for too long") {
+			utils.Error("Kasm %s stuck in 'requested' state. Attempting to destroy and recreate.", kasm.KasmID)
+			r.client.DestroyKasm(kasm.KasmID, userID)
+			utils.Console("Giving the new agent a chance to catch up. Sleeiping for 5 minutes")
+			time.Sleep(5 * time.Minute)
+			return r.createAndTestKasm(numKasms, userID) // Recursive call to retry
+		}
 		utils.Error("Failed waiting for Kasm %s to be ready: %v", kasm.KasmID, err)
+		result.ExecutionError = fmt.Sprintf("Failed waiting for Kasm to be ready: %v", err)
 		return result
 	}
 
@@ -97,29 +114,55 @@ func (r *Runner) createAndTestKasm(numKasms int, userID string) models.KasmResul
 
 	// Step 3: Execute command
 	utils.Info("Step 3: Executing command on Kasm %s", kasm.KasmID)
-	command := r.getCommandToExecute()
-	err = r.client.ExecCommand(kasm.KasmID, userID, command)
-	if err != nil {
-		utils.Error("Failed to execute command on Kasm %s: %v", kasm.KasmID, err)
-		result.ExecutionError = fmt.Sprintf("Failed to execute command: %v", err)
+
+	if r.command == "all" {
+		// Execute CPU test
+		err = r.client.ExecCommand(kasm.KasmID, userID, r.getCPUCommand())
+		if err != nil {
+			utils.Error("Failed to execute CPU command on Kasm %s: %v", kasm.KasmID, err)
+			result.ExecutionError = fmt.Sprintf("Failed to execute CPU command: %v", err)
+		} else {
+			utils.Info("CPU command executed on Kasm %s", kasm.KasmID)
+		}
+
+		// Execute Network test
+		err = r.client.ExecCommand(kasm.KasmID, userID, r.getNetworkCommand())
+		if err != nil {
+			utils.Error("Failed to execute Network command on Kasm %s: %v", kasm.KasmID, err)
+			result.ExecutionError += fmt.Sprintf(" Failed to execute Network command: %v", err)
+		} else {
+			utils.Info("Network command executed on Kasm %s", kasm.KasmID)
+		}
 	} else {
-		utils.Info("Command executed on Kasm %s", kasm.KasmID)
+		// Execute single command for other cases
+		command := r.getCommandToExecute()
+		err = r.client.ExecCommand(kasm.KasmID, userID, command)
+		if err != nil {
+			utils.Error("Failed to execute command on Kasm %s: %v", kasm.KasmID, err)
+			result.ExecutionError = fmt.Sprintf("Failed to execute command: %v", err)
+		} else {
+			utils.Info("Command executed on Kasm %s", kasm.KasmID)
+		}
 	}
 
-	utils.Info("Completed test for Kasm %d", numKasms)
+	utils.Info("Completed test for Kasm %d", numKasms+1)
 	return result
+}
+
+func (r *Runner) getCPUCommand() string {
+	return "dd if=/dev/zero of=/dev/null bs=1M count=1000"
+}
+
+func (r *Runner) getNetworkCommand() string {
+	return "wget -O /dev/null https://releases.ubuntu.com/22.04/ubuntu-22.04.3-live-server-amd64.iso"
 }
 
 func (r *Runner) getCommandToExecute() string {
 	switch r.command {
 	case "cpu":
-		// 1000 MB of writes to /dev/null
-		return "dd if=/dev/zero of=/dev/null bs=1M count=1000"
+		return r.getCPUCommand()
 	case "network":
-		// Downloads a 10MB file 10 times without saving file
-		return "for i in {1..10}; do wget -O /dev/null http://speedtest.wdc01.softlayer.com/downloads/test10.zip; done"
-	case "all":
-		return "(dd if=/dev/zero of=/dev/null bs=1M count=1000 &) && (for i in {1..10}; do wget -O /dev/null http://speedtest.wdc01.softlayer.com/downloads/test10.zip; done &) && wait"
+		return r.getNetworkCommand()
 	default:
 		return "echo 'Hello, Kasm!'"
 	}

--- a/internal/utils/logging.go
+++ b/internal/utils/logging.go
@@ -1,36 +1,75 @@
 package utils
 
 import (
+	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"sync"
 )
 
 var (
-	infoLogger  *log.Logger
-	errorLogger *log.Logger
-	once        sync.Once
+	fileLogger    *log.Logger
+	consoleLogger *log.Logger
+	logFile       *os.File
+	once          sync.Once
 )
 
 // InitLoggers initializes the loggers
-func InitLoggers() {
+func InitLoggers() error {
+	var initError error
 	once.Do(func() {
-		infoLogger = log.New(os.Stdout, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile)
-		errorLogger = log.New(os.Stderr, "ERROR: ", log.Ldate|log.Ltime|log.Lshortfile)
+		// Create log file in the same directory as the executable
+		execPath, err := os.Executable()
+		if err != nil {
+			initError = fmt.Errorf("error getting executable path: %w", err)
+			return
+		}
+		logFilePath := filepath.Join(filepath.Dir(execPath), "stress-test.log")
+		logFile, err = os.OpenFile(logFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			initError = fmt.Errorf("error opening log file: %w", err)
+			return
+		}
+
+		fileLogger = log.New(logFile, "", log.Ldate|log.Ltime|log.Lshortfile)
+		consoleLogger = log.New(os.Stdout, "", 0) // Minimal console output
 	})
+	return initError
 }
 
-// Info logs an info message
+// CloseLogFile closes the log file
+func CloseLogFile() {
+	if logFile != nil {
+		logFile.Close()
+	}
+}
+
+// Info logs an info message to file and prints a simplified version to console
 func Info(format string, v ...interface{}) {
-	infoLogger.Printf(format, v...)
+	message := fmt.Sprintf(format, v...)
+	fileLogger.Printf("INFO: %s", message)
 }
 
-// Error logs an error message
+// Console prints a message to the console
+func Console(format string, v ...interface{}) {
+	message := fmt.Sprintf(format, v...)
+	consoleLogger.Print(message)
+}
+
+// Error logs an error message to file and console
 func Error(format string, v ...interface{}) {
-	errorLogger.Printf(format, v...)
+	message := fmt.Sprintf(format, v...)
+	fileLogger.Printf("ERROR: %s", message)
+	consoleLogger.Printf("ERROR: %s", message)
+	consoleLogger.Println("See stress-test.log for more info")
 }
 
 // Fatal logs an error message and then exits the program
 func Fatal(format string, v ...interface{}) {
-	errorLogger.Fatalf(format, v...)
+	message := fmt.Sprintf(format, v...)
+	fileLogger.Printf("FATAL: %s", message)
+	consoleLogger.Printf("FATAL: %s", message)
+	consoleLogger.Println("See stress-test.log for more info")
+	os.Exit(1)
 }


### PR DESCRIPTION
- Added CLI flag for `-c, --command`
	- Will run a different command or commands on each session dependent on flag input
- Added long form CLI flag usage
- Updated README to reflect new flags
- Removed default value for APIHost from config
- Removed function `handleAPIResponse()` from client.go as it was unused
- Updated command execution to change bases on input from `-c, --command`
- Removed references to command output as the Kasm API does not return this information
- Now starts all sessions and waits for user input to delete sessions
- Fixed logic on waiting for agent to spin up
- Logging now goes to stress-test.log, much less verbose in console