### PR TITLE
Fixing typo

### DIFF
--- a/internal/api/kasm.go
+++ b/internal/api/kasm.go
@@ -112,7 +112,7 @@ func (c *Client) DestroyKasm(kasmID, userID string) error {
 func (c *Client) WaitForKasmReady(kasmID, image_id string, timeout time.Duration) error {
 	start := time.Now()
 	requestedTime := time.Time{}
-	maxRequestedTime := 3 * time.Minute // Maximum time to wait in "requested" state
+	maxRequestedTime := 5 * time.Minute // Maximum time to wait in "requested" state
 	lastNotificationTime := time.Time{}
 	notificationInterval := 30 * time.Second
 

--- a/internal/stress/runner.go
+++ b/internal/stress/runner.go
@@ -96,7 +96,7 @@ func (r *Runner) createAndTestKasm(numKasms int, userID string) models.KasmResul
 
 	// Step 2: Wait for Kasm to be ready
 	utils.Info("Step 2: Waiting for Kasm %s to be ready", kasm.KasmID)
-	err = r.client.WaitForKasmReady(kasm.KasmID, userID, 5*time.Minute)
+	err = r.client.WaitForKasmReady(kasm.KasmID, userID, 10*time.Minute)
 	if err != nil {
 		if strings.Contains(err.Error(), "stuck in 'requested' state for too long") {
 			utils.Error("Kasm %s stuck in 'requested' state. Attempting to destroy and recreate.", kasm.KasmID)


### PR DESCRIPTION
- Fixed typo in runner.go and kasm.go
- Set request time to 5 minutes
- Set sleep to 5 minutes for agent catch-up